### PR TITLE
Registries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ parking_lot = "0.12"
 paste = "1.0"
 rgl-input = { path = "crates/rgl-input" }
 rgl-level = { path = "crates/rgl-level" }
+rgl-registry = { path = "crates/rgl-registry" }
 
 [workspace.package]
 version = "0.1.0"
@@ -32,5 +33,6 @@ edition = "2021"
 bevy.workspace = true
 rgl-input.workspace = true
 rgl-level.workspace = true
+rgl-registry.workspace = true
 bevy_ecs_tilemap.workspace = true
 fastrand.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ bevy = { version = "0.12" }
 bevy_ecs_tilemap = { git = "https://github.com/divark/bevy_ecs_tilemap", branch = "0.12-fixes" }
 derive_more = "0.99"
 fastrand = "2.0"
+ctor = "0.2"
+lazy_static = "1.4"
+parking_lot = "0.12"
+paste = "1.0"
 rgl-input = { path = "crates/rgl-input" }
 rgl-level = { path = "crates/rgl-level" }
 

--- a/crates/rgl-input/Cargo.toml
+++ b/crates/rgl-input/Cargo.toml
@@ -6,3 +6,4 @@ edition.workspace = true
 [dependencies]
 bevy.workspace = true
 derive_more.workspace = true
+rgl-registry.workspace = true

--- a/crates/rgl-input/src/lib.rs
+++ b/crates/rgl-input/src/lib.rs
@@ -17,7 +17,9 @@ impl Plugin for BindingPlugin {
         app.configure_sets(PreUpdate, BindingSet.after(InputSystem))
             .add_systems(PreUpdate, key_binding_input.in_set(BindingSet))
             .register_two_sided_data_id2value::<BindingRegistry, &'static str>("bindings")
-            .register_two_sided_data_id2value::<BindingCategoryRegistry, &'static str>("binding_categories");
+            .register_two_sided_data_id2value::<BindingCategoryRegistry, &'static str>(
+                "binding_categories",
+            );
     }
 }
 

--- a/crates/rgl-level/Cargo.toml
+++ b/crates/rgl-level/Cargo.toml
@@ -7,3 +7,4 @@ edition.workspace = true
 bevy.workspace = true
 bevy_ecs_tilemap.workspace = true
 fastrand.workspace = true
+rgl-registry.workspace = true

--- a/crates/rgl-registry/Cargo.toml
+++ b/crates/rgl-registry/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rgl-registry"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+bevy.workspace = true
+ctor.workspace = true
+parking_lot.workspace = true
+paste.workspace = true

--- a/crates/rgl-registry/src/app.rs
+++ b/crates/rgl-registry/src/app.rs
@@ -1,0 +1,256 @@
+use std::{any::TypeId, hash::Hash};
+
+use bevy::{
+    prelude::*,
+    utils::{HashMap, HashSet},
+};
+
+use crate::{
+    Registry, RegistryDataCell, RegistryId, RegistryIdMap, RegistryItem, RegistryMapConvert,
+    RegistryMapInsert,
+};
+
+pub trait RegistryAppExt {
+    fn register_two_sided_data_id2id<I1, I2>(&mut self) -> &mut Self
+    where
+        I1: RegistryItem,
+        I2: RegistryItem;
+
+    fn register_two_sided_data_id2value<I, V>(&mut self, value: V) -> &mut Self
+    where
+        I: RegistryItem,
+        V: Hash,
+        V: Clone,
+        V: Sync + Send + 'static,
+        V: Eq;
+
+    fn register_one_sided_data<I, V>(&mut self, value: V) -> &mut Self
+    where
+        I: RegistryItem,
+        V: Sync + Send + 'static;
+
+    fn keep_changable_two_sided_data_id2id<R1, R2>(&mut self) -> &mut Self
+    where
+        R1: Registry,
+        R2: Registry;
+
+    fn keep_changable_two_sided_data_id2value<R, V>(&mut self) -> &mut Self
+    where
+        R: Registry,
+        V: Hash,
+        V: Clone,
+        V: Sync + Send + 'static,
+        V: Eq;
+
+    fn keep_changable_one_sided_data<R, V>(&mut self) -> &mut Self
+    where
+        R: Registry,
+        V: Sync + Send + 'static;
+}
+
+#[derive(Resource, Default)]
+struct ConvertSystemsData {
+    added_systems: HashSet<TypeId>,
+    cancelled_systems: HashSet<TypeId>,
+}
+
+impl ConvertSystemsData {
+    pub fn is_added<T: 'static>(&self, _marker: &T) -> bool {
+        self.added_systems.contains(&TypeId::of::<T>())
+    }
+
+    pub fn add_if_not_added<T: IntoSystemConfigs<M> + 'static, M>(
+        app: &mut App,
+        func: T,
+        pre: bool,
+    ) {
+        let mut acs = app.world.remove_resource::<ConvertSystemsData>().unwrap();
+        if !acs.is_added(&func) {
+            if pre {
+                app.add_systems(PreStartup, func);
+            } else {
+                app.add_systems(Startup, func);
+            }
+            acs.added_systems.insert(TypeId::of::<T>());
+        }
+        app.insert_resource(acs);
+    }
+
+    pub fn cancel<T: 'static>(&mut self, _marker: T) {
+        self.cancelled_systems.insert(TypeId::of::<T>());
+    }
+
+    pub fn is_cancelled<T: 'static>(&self, _marker: T) -> bool {
+        self.cancelled_systems.contains(&TypeId::of::<T>())
+    }
+}
+
+fn convert_system<I, V, C1, C2>(mut commands: Commands)
+where
+    I: Sync + Send + 'static,
+    V: Sync + Send + 'static,
+    C1: Sync + Send + 'static,
+    C2: Sync + Send + 'static,
+    C1::Converted: Sync + Send + 'static,
+    C2::Converted: Sync + Send + 'static,
+    C1: RegistryMapConvert,
+    C2: RegistryMapConvert,
+{
+    commands.add(|world: &mut World| {
+        if !world
+            .resource::<ConvertSystemsData>()
+            .is_cancelled(convert_system::<I, V, C1, C2>)
+        {
+            if let Some(data_cell) = world.remove_resource::<RegistryDataCell<I, V, C1, C2>>() {
+                world.insert_resource(data_cell.convert());
+            }
+        }
+    });
+}
+
+fn remove_added_convert_systems_res(mut commands: Commands) {
+    commands.remove_resource::<ConvertSystemsData>();
+}
+
+fn csd_setup(app: &mut App) {
+    app.world.init_resource::<ConvertSystemsData>();
+    ConvertSystemsData::add_if_not_added(app, remove_added_convert_systems_res, false);
+}
+
+fn insert<I, V, C1, C2>(app: &mut App, id: I, value: V)
+where
+    I: Sync + Send + 'static,
+    V: Sync + Send + 'static,
+    C1: Sync + Send + 'static,
+    C2: Sync + Send + 'static,
+    C1::Converted: Sync + Send + 'static,
+    C2::Converted: Sync + Send + 'static,
+    I: Clone,
+    V: Clone,
+    C1: Default,
+    C2: Default,
+    C1: RegistryMapConvert,
+    C2: RegistryMapConvert,
+    C1: RegistryMapInsert<I, V>,
+    C2: RegistryMapInsert<V, I>,
+{
+    ConvertSystemsData::add_if_not_added(app, convert_system::<I, V, C1, C2>, true);
+    app.init_resource::<RegistryDataCell<I, V, C1, C2>>();
+    // TODO: Debug?
+    let _ = app
+        .world
+        .resource_mut::<RegistryDataCell<I, V, C1, C2>>()
+        .insert(id, value);
+}
+
+fn insert_one_sided<I, V, C1>(app: &mut App, id: I, value: V)
+where
+    I: Sync + Send + 'static,
+    V: Sync + Send + 'static,
+    C1: Sync + Send + 'static,
+    C1::Converted: Sync + Send + 'static,
+    C1: Default,
+    C1: RegistryMapConvert,
+    C1: RegistryMapInsert<I, V>,
+{
+    ConvertSystemsData::add_if_not_added(app, convert_system::<I, V, C1, ()>, true);
+    app.init_resource::<RegistryDataCell<I, V, C1, ()>>();
+    // TODO: Debug?
+    let _ = app
+        .world
+        .resource_mut::<RegistryDataCell<I, V, C1, ()>>()
+        .insert_one_sided(id, value);
+}
+
+impl RegistryAppExt for App {
+    fn register_two_sided_data_id2id<I1, I2>(&mut self) -> &mut Self
+    where
+        I1: RegistryItem,
+        I2: RegistryItem,
+    {
+        csd_setup(self);
+        insert::<
+            RegistryId<I1::Registry>,
+            RegistryId<I2::Registry>,
+            RegistryIdMap<I1::Registry, RegistryId<I2::Registry>>,
+            RegistryIdMap<I2::Registry, RegistryId<I1::Registry>>,
+        >(self, RegistryId::new::<I1>(), RegistryId::new::<I2>());
+        self
+    }
+
+    fn register_two_sided_data_id2value<I, V>(&mut self, value: V) -> &mut Self
+    where
+        I: RegistryItem,
+        V: Hash,
+        V: Clone,
+        V: Sync + Send + 'static,
+        V: Eq,
+    {
+        csd_setup(self);
+        insert::<
+            RegistryId<I::Registry>,
+            V,
+            RegistryIdMap<I::Registry, V>,
+            HashMap<V, RegistryId<I::Registry>>,
+        >(self, RegistryId::new::<I>(), value);
+        self
+    }
+
+    fn register_one_sided_data<I, V>(&mut self, value: V) -> &mut Self
+    where
+        I: RegistryItem,
+        V: Sync + Send + 'static,
+    {
+        csd_setup(self);
+        insert_one_sided::<RegistryId<I::Registry>, V, RegistryIdMap<I::Registry, V>>(
+            self,
+            RegistryId::new::<I>(),
+            value,
+        );
+        self
+    }
+
+    fn keep_changable_two_sided_data_id2id<R1, R2>(&mut self) -> &mut Self
+    where
+        R1: Registry,
+        R2: Registry,
+    {
+        csd_setup(self);
+        self.world.resource_mut::<ConvertSystemsData>().cancel(
+            convert_system::<
+                RegistryId<R1>,
+                RegistryId<R2>,
+                RegistryIdMap<R1, RegistryId<R2>>,
+                RegistryIdMap<R2, RegistryId<R1>>,
+            >,
+        );
+        self
+    }
+
+    fn keep_changable_two_sided_data_id2value<R, V>(&mut self) -> &mut Self
+    where
+        R: Registry,
+        V: Hash,
+        V: Clone,
+        V: Sync + Send + 'static,
+        V: Eq,
+    {
+        csd_setup(self);
+        self.world.resource_mut::<ConvertSystemsData>().cancel(
+            convert_system::<RegistryId<R>, V, RegistryIdMap<R, V>, HashMap<V, RegistryId<R>>>,
+        );
+        self
+    }
+
+    fn keep_changable_one_sided_data<R, V>(&mut self) -> &mut Self
+    where
+        R: Registry,
+        V: Sync + Send + 'static,
+    {
+        csd_setup(self);
+        self.world
+            .resource_mut::<ConvertSystemsData>()
+            .cancel(convert_system::<RegistryId<R>, V, RegistryIdMap<R, V>, ()>);
+        self
+    }
+}

--- a/crates/rgl-registry/src/app.rs
+++ b/crates/rgl-registry/src/app.rs
@@ -29,6 +29,11 @@ pub trait RegistryAppExt {
         I: RegistryItem,
         V: Sync + Send + 'static;
 
+    fn register_one_sided_vec_data<I, V>(&mut self, value: V) -> &mut Self
+    where
+        I: RegistryItem,
+        V: Sync + Send + 'static;
+
     fn keep_changable_two_sided_data_id2id<R1, R2>(&mut self) -> &mut Self
     where
         R1: Registry,
@@ -207,6 +212,25 @@ impl RegistryAppExt for App {
             RegistryId::new::<I>(),
             value,
         );
+        self
+    }
+
+    fn register_one_sided_vec_data<I, V>(&mut self, value: V) -> &mut Self
+    where
+        I: RegistryItem,
+        V: Sync + Send + 'static,
+    {
+        csd_setup(self);
+        self.init_resource::<RegistryDataCell<RegistryId<I::Registry>, Vec<V>, RegistryIdMap<I::Registry, Vec<V>>>>();
+        ConvertSystemsData::add_if_not_added(
+            self,
+            convert_system::<RegistryId<I::Registry>, V, RegistryIdMap<I::Registry, Vec<V>>, ()>,
+            true,
+        );
+        self.world
+            .resource_mut::<RegistryDataCell<RegistryId<I::Registry>, Vec<V>, RegistryIdMap<I::Registry, Vec<V>>>>()
+            .value_mut_or_insert_default(&RegistryId::new::<I>())
+            .push(value);
         self
     }
 

--- a/crates/rgl-registry/src/data.rs
+++ b/crates/rgl-registry/src/data.rs
@@ -1,0 +1,320 @@
+use std::{
+    any::type_name,
+    hash::{BuildHasher, Hash},
+    marker::PhantomData,
+};
+
+use bevy::{ecs::system::Resource, log::error, utils::hashbrown::HashMap};
+
+use crate::{id::RegistryId, Registry, RegistryItem};
+
+pub trait RegistryMapInsert<K, V> {
+    fn insert(&mut self, key: K, value: V) -> Option<V>;
+}
+
+pub trait RegistryMapGet<K, V> {
+    fn get(&self, key: &K) -> Option<&V>;
+}
+
+pub trait RegistryMapGetMut<K, V> {
+    fn get_mut(&mut self, key: &K) -> Option<&mut V>;
+}
+
+pub trait RegistryMapConvert {
+    type Converted;
+
+    fn convert(self) -> Self::Converted;
+}
+
+impl<K, V, S> RegistryMapInsert<K, V> for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+}
+
+impl<K, V, S> RegistryMapGet<K, V> for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn get(&self, key: &K) -> Option<&V> {
+        self.get(key)
+    }
+}
+
+impl<K, V, S> RegistryMapGetMut<K, V> for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.get_mut(key)
+    }
+}
+
+impl<K, V, S> RegistryMapConvert for HashMap<K, V, S> {
+    type Converted = HashMap<K, V, S>;
+
+    fn convert(self) -> Self::Converted {
+        self
+    }
+}
+
+pub struct RegistryIdMap<R: Registry, V> {
+    objects: Vec<Option<V>>,
+    _marker: PhantomData<R>,
+}
+
+impl<R: Registry, V> RegistryMapInsert<RegistryId<R>, V> for RegistryIdMap<R, V> {
+    fn insert(&mut self, key: RegistryId<R>, value: V) -> Option<V> {
+        let index = key.numeric() as usize;
+        if index >= self.objects.len() {
+            self.objects.resize_with(index + 1, || None);
+        }
+        self.objects
+            .get_mut(index)
+            .map(|it| std::mem::replace(it, Some(value)))
+            .flatten()
+    }
+}
+
+impl<R: Registry, V> RegistryMapGet<RegistryId<R>, V> for RegistryIdMap<R, V> {
+    fn get(&self, key: &RegistryId<R>) -> Option<&V> {
+        self.objects
+            .get(key.clone().numeric() as usize)
+            .map(Option::as_ref)
+            .flatten()
+    }
+}
+
+impl<R: Registry, V> RegistryMapGetMut<RegistryId<R>, V> for RegistryIdMap<R, V> {
+    fn get_mut(&mut self, key: &RegistryId<R>) -> Option<&mut V> {
+        self.objects
+            .get_mut(key.clone().numeric() as usize)
+            .map(Option::as_mut)
+            .flatten()
+    }
+}
+
+impl<R: Registry, V> RegistryMapConvert for RegistryIdMap<R, V> {
+    type Converted = ConvertedRegistryIdMap<R, V>;
+
+    fn convert(self) -> Self::Converted {
+        let mut any_missing = false;
+
+        self.objects
+            .iter()
+            .chain(std::iter::repeat(&None).take(R::count() - self.objects.len()))
+            .enumerate()
+            .filter(|(_, v)| v.is_none())
+            .for_each(|(i, _)| {
+                error!(
+                    "There is no binding with id {} in RegistryMap for registry {}",
+                    i,
+                    type_name::<R>()
+                );
+
+                any_missing = true;
+            });
+
+        if any_missing {
+            panic!("RegistryMap couldn't be finished");
+        }
+
+        ConvertedRegistryIdMap {
+            objects: self.objects.into_iter().map(Option::unwrap).collect(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<R: Registry, V> RegistryIdMap<R, V> {
+    pub fn iter(&self) -> impl Iterator<Item = &V> + '_ {
+        self.objects.iter().filter_map(Option::as_ref)
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut V> + '_ {
+        self.objects.iter_mut().filter_map(Option::as_mut)
+    }
+}
+
+impl<R: Registry, V> Default for RegistryIdMap<R, V> {
+    fn default() -> Self {
+        Self {
+            objects: vec![],
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct ConvertedRegistryIdMap<R: Registry, V> {
+    objects: Vec<V>,
+    _marker: PhantomData<R>,
+}
+
+impl<R: Registry, V> RegistryMapGet<RegistryId<R>, V> for ConvertedRegistryIdMap<R, V> {
+    fn get(&self, key: &RegistryId<R>) -> Option<&V> {
+        self.objects.get(key.clone().numeric() as usize)
+    }
+}
+
+impl<R: Registry, V> RegistryMapGetMut<RegistryId<R>, V> for ConvertedRegistryIdMap<R, V> {
+    fn get_mut(&mut self, key: &RegistryId<R>) -> Option<&mut V> {
+        self.objects.get_mut(key.clone().numeric() as usize)
+    }
+}
+
+impl<R: Registry, V> RegistryMapInsert<RegistryId<R>, V> for ConvertedRegistryIdMap<R, V> {
+    fn insert(&mut self, key: RegistryId<R>, value: V) -> Option<V> {
+        let index = key.numeric() as usize;
+        if self.objects.len() <= index {
+            panic!("ConvertedRegistryIdMap doesn't support creating new values");
+        }
+        Some(std::mem::replace(&mut self.objects[index], value))
+    }
+}
+
+impl<R: Registry, V> ConvertedRegistryIdMap<R, V> {
+    pub fn iter(&self) -> core::slice::Iter<'_, V> {
+        self.objects.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, V> {
+        self.objects.iter_mut()
+    }
+}
+
+impl RegistryMapConvert for () {
+    type Converted = Self;
+
+    fn convert(self) -> Self::Converted {
+        self
+    }
+}
+
+pub type RegistryTwoSidedDataCellId2Value<R, V> = RegistryDataCell<
+    RegistryId<R>,
+    V,
+    <RegistryIdMap<R, V> as RegistryMapConvert>::Converted,
+    <HashMap<V, RegistryId<R>> as RegistryMapConvert>::Converted,
+>;
+
+pub type RegistryTwoSidedDataCellId2Id<R1, R2> = RegistryDataCell<
+    RegistryId<R1>,
+    RegistryId<R2>,
+    <RegistryIdMap<R1, RegistryId<R2>> as RegistryMapConvert>::Converted,
+    <RegistryIdMap<R2, RegistryId<R1>> as RegistryMapConvert>::Converted,
+>;
+
+pub type RegistryOneSidedDataCell<R, V> =
+    RegistryDataCell<RegistryId<R>, V, <RegistryIdMap<R, V> as RegistryMapConvert>::Converted>;
+
+pub type ChangableRegistryTwoSidedDataCellId2Value<R, V> =
+    RegistryDataCell<RegistryId<R>, V, RegistryIdMap<R, V>, HashMap<V, RegistryId<R>>>;
+
+pub type ChangableRegistryTwoSidedDataCellId2Id<R1, R2> = RegistryDataCell<
+    RegistryId<R1>,
+    RegistryId<R2>,
+    RegistryIdMap<R1, RegistryId<R2>>,
+    RegistryIdMap<R2, RegistryId<R1>>,
+>;
+
+pub type ChangableRegistryOneSidedDataCell<R, V> =
+    RegistryDataCell<RegistryId<R>, V, RegistryIdMap<R, V>>;
+
+#[doc(hidden)]
+#[derive(Resource)]
+pub struct RegistryDataCell<I, V, C1, C2 = ()> {
+    pub c1: C1,
+    pub c2: C2,
+    _marker: PhantomData<(I, V)>,
+}
+
+impl<Id, Value, C1, C2> RegistryDataCell<Id, Value, C1, C2> {
+    pub fn value(&self, id: &Id) -> Option<&Value>
+    where
+        C1: RegistryMapGet<Id, Value>,
+    {
+        self.c1.get(id)
+    }
+
+    pub fn id(&self, value: &Value) -> Option<&Id>
+    where
+        C2: RegistryMapGet<Value, Id>,
+    {
+        self.c2.get(value)
+    }
+
+    pub fn insert(&mut self, id: Id, value: Value) -> (Option<Value>, Option<Id>)
+    where
+        C1: RegistryMapInsert<Id, Value>,
+        C2: RegistryMapInsert<Value, Id>,
+        Value: Clone,
+        Id: Clone,
+    {
+        (
+            self.c1.insert(id.clone(), value.clone()),
+            self.c2.insert(value.clone(), id.clone()),
+        )
+    }
+
+    pub fn convert(self) -> RegistryDataCell<Id, Value, C1::Converted, C2::Converted>
+    where
+        C1: RegistryMapConvert,
+        C2: RegistryMapConvert,
+    {
+        RegistryDataCell {
+            c1: self.c1.convert(),
+            c2: self.c2.convert(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<R, Value, C1, C2> RegistryDataCell<RegistryId<R>, Value, C1, C2>
+where
+    R: Registry,
+{
+    pub fn value_ty<I>(&self) -> Option<&Value>
+    where
+        I: RegistryItem<Registry = R>,
+        C1: RegistryMapGet<RegistryId<R>, Value>,
+    {
+        self.c1.get(&RegistryId::new::<I>())
+    }
+}
+
+impl<Id, Value, C1> RegistryDataCell<Id, Value, C1, ()> {
+    pub fn value_mut(&mut self, id: &Id) -> Option<&mut Value>
+    where
+        C1: RegistryMapGetMut<Id, Value>,
+    {
+        self.c1.get_mut(id)
+    }
+
+    pub fn insert_one_sided(&mut self, id: Id, value: Value) -> Option<Value>
+    where
+        C1: RegistryMapInsert<Id, Value>,
+    {
+        self.c1.insert(id, value)
+    }
+}
+
+impl<I, V, C1, C2> Default for RegistryDataCell<I, V, C1, C2>
+where
+    C1: Default,
+    C2: Default,
+{
+    fn default() -> Self {
+        Self {
+            c1: C1::default(),
+            c2: C2::default(),
+            _marker: PhantomData,
+        }
+    }
+}

--- a/crates/rgl-registry/src/data.rs
+++ b/crates/rgl-registry/src/data.rs
@@ -297,6 +297,30 @@ impl<Id, Value, C1> RegistryDataCell<Id, Value, C1, ()> {
         self.c1.get_mut(id)
     }
 
+    pub fn value_mut_or_insert_with(&mut self, id: &Id, with: impl FnOnce() -> Value) -> &mut Value
+    where
+        Id: Clone,
+        C1: RegistryMapGetMut<Id, Value>,
+        C1: RegistryMapInsert<Id, Value>,
+    {
+        // TODO: Some issues with borrow checker
+        if self.c1.get_mut(id).is_none() {
+            self.c1.insert(id.clone(), with());
+        }
+
+        self.c1.get_mut(id).unwrap()
+    }
+
+    pub fn value_mut_or_insert_default(&mut self, id: &Id) -> &mut Value
+    where
+        Id: Clone,
+        Value: Default,
+        C1: RegistryMapGetMut<Id, Value>,
+        C1: RegistryMapInsert<Id, Value>,
+    {
+        self.value_mut_or_insert_with(id, Default::default)
+    }
+
     pub fn insert_one_sided(&mut self, id: Id, value: Value) -> Option<Value>
     where
         C1: RegistryMapInsert<Id, Value>,

--- a/crates/rgl-registry/src/id.rs
+++ b/crates/rgl-registry/src/id.rs
@@ -1,0 +1,78 @@
+use crate::*;
+
+#[repr(transparent)]
+pub struct RegistryId<R: Registry>(R::Id);
+
+impl<R: Registry> RegistryId<R> {
+    pub fn new<I>() -> Self
+    where
+        I: RegistryItem<Registry = R>,
+    {
+        Self(I::id())
+    }
+
+    pub fn is<I>(&self) -> bool
+    where
+        I: RegistryItem<Registry = R>,
+    {
+        self.0 == I::id()
+    }
+
+    pub fn numeric(self) -> RegistryIdNumeric {
+        self.0.into()
+    }
+}
+
+impl<R: Registry> PartialEq for RegistryId<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<R: Registry> Eq for RegistryId<R> {}
+
+impl<R: Registry> Clone for RegistryId<R> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<R: Registry> Copy for RegistryId<R> where R::Id: Copy {}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnknownRegistryId(RegistryIdNumeric);
+
+impl UnknownRegistryId {
+    pub const NONE: Self = Self(RegistryIdNumeric::MAX);
+
+    pub fn new<I>() -> Self
+    where
+        I: RegistryItem,
+    {
+        Self(I::id().into())
+    }
+
+    /// If the registry of this id and the given one varies, then this method can give incorrect result
+    pub fn is<I>(&self) -> bool
+    where
+        I: RegistryItem,
+    {
+        self.0 == I::id().into()
+    }
+}
+
+impl<R: Registry> From<RegistryId<R>> for UnknownRegistryId {
+    fn from(value: RegistryId<R>) -> Self {
+        Self(value.0.into())
+    }
+}
+
+impl<R: Registry> From<Option<RegistryId<R>>> for UnknownRegistryId {
+    fn from(value: Option<RegistryId<R>>) -> Self {
+        match value {
+            Some(rid) => Self::from(rid),
+            None => Self::NONE,
+        }
+    }
+}

--- a/crates/rgl-registry/src/lib.rs
+++ b/crates/rgl-registry/src/lib.rs
@@ -1,10 +1,32 @@
-use std::any::type_name;
-use std::iter;
-use std::marker::PhantomData;
+mod app;
+mod data;
+mod id;
 
-use bevy::prelude::*;
-use bevy::utils::HashMap;
-use parking_lot::Mutex;
+pub use app::*;
+pub use data::*;
+pub use id::*;
+
+type RegistryIdNumeric = u16;
+
+pub trait Registry: 'static + Sync + Send + Sized {
+    type Id: 'static + Clone + Sync + Send + Sized + PartialEq + Eq + Into<RegistryIdNumeric>;
+
+    fn reserve_id() -> Self::Id;
+
+    fn count() -> usize;
+}
+
+pub trait RegistryItem: 'static + Sync + Send + Sized {
+    type Registry: Registry;
+
+    fn id() -> <Self::Registry as Registry>::Id;
+}
+
+pub trait ChildRegistry: Registry + RegistryItem<Registry = Registries> {}
+
+pub struct Registries;
+
+__registry_impl!(Registries, RegistryIdNumeric);
 
 #[doc(hidden)]
 pub mod __private {
@@ -13,231 +35,22 @@ pub mod __private {
     pub use paste;
 }
 
-pub struct RegistryPlugin<R: Registry>(PhantomData<R>);
-
-impl<R: Registry> Default for RegistryPlugin<R> {
-    fn default() -> Self {
-        Self(PhantomData)
-    }
-}
-
-impl<R: Registry> Plugin for RegistryPlugin<R> {
-    fn build(&self, app: &mut App) {
-        app.init_resource::<RegistryData<R>>();
-
-        #[cfg(debug_assertions)]
-        app.add_systems(PostStartup, check_unregistered::<R>);
-    }
-}
-
-fn check_unregistered<R: Registry>(registry: Res<RegistryData<R>>) {
-    registry.unregistered().for_each(|i| {
-        warn!(
-            "Unregistered item in registry {}, item index: {}",
-            type_name::<R>(),
-            i
-        );
-    });
-}
-
-pub trait RegistryItem: Sync + Send + 'static {
-    type R: Registry;
-
-    fn id() -> <Self::R as Registry>::Id;
-}
-
-pub trait Registry: Sync + Send + 'static {
-    type Id: PartialEq + Clone + Sync + Send + Into<usize> + 'static;
-
-    fn next_id() -> &'static Mutex<Self::Id>;
-}
-
-pub trait ChildRegistry: Registry + RegistryItem<R = RegistriesRegistry> {}
-
-#[repr(transparent)]
-pub struct RegistryId<R: Registry>(R::Id);
-
-impl<R: Registry> RegistryId<R> {
-    pub fn from_id(id: R::Id) -> Self {
-        Self(id)
-    }
-
-    pub fn from_item<I: RegistryItem<R = R>>() -> Self {
-        Self(I::id())
-    }
-
-    pub fn is<I: RegistryItem<R = R>>(&self) -> bool {
-        self.0 == I::id()
-    }
-}
-
-impl<R: Registry> PartialEq for RegistryId<R> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<R: Registry> Clone for RegistryId<R> {
-    fn clone(&self) -> Self {
-        Self::from_id(self.0.clone())
-    }
-}
-
-impl<R: Registry> Copy for RegistryId<R> where R::Id: Copy {}
-
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub struct UnknownRegistryId(pub usize);
-
-impl UnknownRegistryId {
-    pub const NONE: Self = Self(usize::MAX);
-
-    pub fn from_option<R: Registry>(value: Option<RegistryId<R>>) -> Self {
-        match value {
-            Some(rid) => rid.into(),
-            None => Self::NONE,
-        }
-    }
-}
-
-impl<R: Registry> From<RegistryId<R>> for UnknownRegistryId {
-    fn from(value: RegistryId<R>) -> Self {
-        Self(value.0.into())
-    }
-}
-
-#[derive(Resource, Debug)]
-pub struct RegistryData<R: Registry> {
-    names2id: HashMap<&'static str, R::Id>,
-    id2names: Vec<Option<&'static str>>,
-}
-
-impl<R: Registry> RegistryData<R> {
-    pub fn add(&mut self, name: &'static str, id: R::Id) {
-        self.names2id.insert(name, id.clone());
-        let id = id.into();
-        if self.id2names.len() <= id {
-            self.id2names.resize(id + 1, None);
-        }
-        self.id2names[id] = Some(name);
-    }
-
-    pub fn name(&self, id: R::Id) -> Option<&'static str> {
-        self.id2names.get(id.into()).cloned().flatten()
-    }
-
-    pub fn id(&self, name: &str) -> Option<R::Id> {
-        self.names2id.get(name).cloned()
-    }
-
-    pub fn unregistered(&self) -> impl Iterator<Item = usize> + '_ {
-        let len: usize = R::next_id().lock().clone().into();
-
-        self.id2names
-            .iter()
-            .cloned()
-            .chain(iter::repeat(None).take(len - self.id2names.len()))
-            .enumerate()
-            .filter(|(_, o)| o.is_none())
-            .map(|(i, _)| i)
-    }
-
-    pub fn remove(&mut self, id: R::Id) -> bool {
-        let id: usize = id.into();
-        if let Some(Some(ref name)) = self.id2names.get(id) {
-            self.names2id.remove(name);
-            self.id2names[id] = None;
-            true
-        } else {
-            false
-        }
-    }
-}
-
-impl<R: Registry> Default for RegistryData<R> {
-    fn default() -> Self {
-        Self {
-            names2id: HashMap::new(),
-            id2names: Vec::new(),
-        }
-    }
-}
-
-pub trait RegistryAppMethods {
-    fn register_item<I: RegistryItem>(&mut self, name: &'static str) -> &mut Self;
-}
-
-impl RegistryAppMethods for App {
-    fn register_item<I: RegistryItem>(&mut self, name: &'static str) -> &mut Self {
-        self.init_resource::<RegistryData<I::R>>();
-        self.world
-            .resource_mut::<RegistryData<I::R>>()
-            .add(name, I::id());
-        self
-    }
-}
-
-pub static REGISTRY_NEXT_ID: Mutex<usize> = Mutex::new(0);
-
-/// A special registry, that handles ids of registries. The only registry that can have none id
-pub struct RegistriesRegistry;
-
-impl Registry for RegistriesRegistry {
-    type Id = usize;
-
-    fn next_id() -> &'static Mutex<Self::Id> {
-        &REGISTRY_NEXT_ID
-    }
-}
-
-#[macro_export]
-macro_rules! new_registry {
-    ($registry: ident, $id: ty) => {
-        pub struct $registry;
-
-        $crate::__private::paste::paste! {
-            #[doc(hidden)]
-            #[allow(non_upper_case_globals)]
-            static [<__ $registry _NEXT_ID>]: $crate::__private::parking_lot::Mutex<$id> =
-                $crate::__private::parking_lot::Mutex::<$id>::new(0);
-
-        }
-
-        impl $crate::Registry for $registry {
-            type Id = $id;
-
-            fn next_id() -> &'static $crate::__private::parking_lot::Mutex<$id> {
-                $crate::__private::paste::paste! {
-                    &[<__ $registry _NEXT_ID>]
-                }
-            }
-        }
-
-        $crate::__impl_registry_item!($registry, $crate::RegistriesRegistry);
-
-        impl $crate::ChildRegistry for $registry {}
-    };
-}
-
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __impl_registry_item {
+macro_rules! __registry_item_impl {
     ($item: ident, $registry: ty) => {
         $crate::__private::paste::paste! {
             #[doc(hidden)]
             #[$crate::__private::ctor::ctor]
             #[allow(non_upper_case_globals)]
-            static [<__ $item _ID>]: <$registry as $crate::Registry>::Id = {
-                let mut lock = <$registry as $crate::Registry>::next_id().lock();
-                let id = *lock;
-                *lock += 1;
-                id
-            };
+            static [<__ $item _ID>]: <$registry as $crate::Registry>::Id =
+                <$registry as $crate::Registry>::reserve_id();
         }
 
         impl $crate::RegistryItem for $item {
-            type R = $registry;
+            type Registry = $registry;
 
-            fn id() -> <Self::R as $crate::Registry>::Id {
+            fn id() -> <Self::Registry as $crate::Registry>::Id {
                 $crate::__private::paste::paste! {
                     *[<__ $item _ID>]
                 }
@@ -247,57 +60,100 @@ macro_rules! __impl_registry_item {
 }
 
 #[macro_export]
-macro_rules! new_registry_item {
-    ($item: ident, $registry: ty) => {
-        pub struct $item;
+macro_rules! new_registry_items {
+    ($registry: ty {$($item: ident$(,)?)*}) => {
+        $(
+            pub struct $item;
 
-        $crate::__impl_registry_item!($item, $registry);
+            $crate::__registry_item_impl!($item, $registry);
+        )*
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __registry_impl {
+    ($registry: ident, $id: ty) => {
+        $crate::__private::paste::paste! {
+            #[doc(hidden)]
+            #[allow(non_upper_case_globals)]
+            static [<__ $registry _ID_COUNTER>]: $crate::__private::parking_lot::Mutex<$id> =
+                $crate::__private::parking_lot::Mutex::new(0);
+        }
+
+        impl $crate::Registry for $registry {
+            type Id = $id;
+
+            fn reserve_id() -> Self::Id {
+                $crate::__private::paste::paste! {
+                    let mut lock = [<__ $registry _ID_COUNTER>].lock();
+                    let id = *lock;
+                    *lock += 1;
+                    id
+                }
+            }
+
+            fn count() -> usize {
+                $crate::__private::paste::paste! {
+                    (*[<__ $registry _ID_COUNTER>].lock()).into()
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! new_registry {
+    ($registry: ident, $id: ty) => {
+        pub struct $registry;
+
+        $crate::__registry_impl!($registry, $id);
+        $crate::__registry_item_impl!($registry, $crate::Registries);
+
+        impl $crate::ChildRegistry for $registry {}
     };
 }
 
 #[cfg(test)]
 mod tests {
 
+    use bevy::{app::App, log::LogPlugin};
+
     use super::*;
 
-    new_registry_item!(TestItem1, TestRegistry);
     new_registry!(TestRegistry, u8);
-    new_registry_item!(TestItem2, TestRegistry);
+    new_registry_items!(TestRegistry {
+        TestItem1,
+        TestItem2,
+        TestItem3,
+    });
 
     #[test]
-    fn easy_test() {
-        assert!(
-            TestItem1::id() == 0 || TestItem2::id() == 0,
-            "1: {}, 2: {}",
-            TestItem1::id(),
-            TestItem2::id()
-        );
-        assert!(
-            TestItem1::id() == 1 || TestItem2::id() == 1,
-            "1: {}, 2: {}",
-            TestItem1::id(),
-            TestItem2::id()
-        );
-        assert_ne!(TestItem1::id(), TestItem2::id());
-    }
-
-    #[test]
-    fn bevy_test() {
+    fn test() {
         let mut app = App::new();
+        app.add_plugins(LogPlugin::default())
+            .register_two_sided_data_id2value::<TestItem1, &'static str>("test_1")
+            .register_two_sided_data_id2value::<TestItem2, &'static str>("test_2")
+            .register_two_sided_data_id2value::<TestItem3, &'static str>("test_3")
+            .register_one_sided_data::<TestItem1, u32>(1)
+            .register_one_sided_data::<TestItem2, u32>(2)
+            .register_one_sided_data::<TestItem3, u32>(3);
+        app.update();
 
-        app.add_plugins(RegistryPlugin::<TestRegistry>::default())
-            .register_item::<TestItem1>("Test1");
+        let res = app
+            .world
+            .resource::<RegistryTwoSidedDataCellId2Value<TestRegistry, &'static str>>();
 
-        let registry_data = app.world.resource::<RegistryData<TestRegistry>>();
+        assert_eq!(res.value_ty::<TestItem1>(), Some(&"test_1"));
+        assert_eq!(res.value_ty::<TestItem2>(), Some(&"test_2"));
+        assert_eq!(res.value_ty::<TestItem3>(), Some(&"test_3"));
 
-        assert_eq!(
-            registry_data.unregistered().collect::<Vec<_>>(),
-            vec![TestItem2::id() as usize]
-        );
+        let res = app
+            .world
+            .resource::<RegistryOneSidedDataCell<TestRegistry, u32>>();
 
-        assert_eq!(registry_data.id("Test1"), Some(TestItem1::id()),);
-        assert_eq!(registry_data.name(TestItem1::id()), Some("Test1"));
-        assert_eq!(registry_data.id("Test2"), None);
-        assert_eq!(registry_data.name(TestItem2::id()), None);
+        assert_eq!(res.value_ty::<TestItem1>(), Some(&1));
+        assert_eq!(res.value_ty::<TestItem2>(), Some(&2));
+        assert_eq!(res.value_ty::<TestItem3>(), Some(&3));
     }
 }

--- a/crates/rgl-registry/src/lib.rs
+++ b/crates/rgl-registry/src/lib.rs
@@ -1,0 +1,224 @@
+use std::any::type_name;
+use std::iter;
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use bevy::utils::HashMap;
+use parking_lot::Mutex;
+
+#[doc(hidden)]
+pub mod __private {
+    pub use ctor;
+    pub use parking_lot;
+    pub use paste;
+}
+
+pub struct RegistryPlugin<R: Registry>(PhantomData<R>);
+
+impl<R: Registry> Default for RegistryPlugin<R> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<R: Registry> Plugin for RegistryPlugin<R> {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<RegistryData<R>>();
+
+        #[cfg(debug_assertions)]
+        app.add_systems(PostStartup, check_unregistered::<R>);
+    }
+}
+
+fn check_unregistered<R: Registry>(registry: Res<RegistryData<R>>) {
+    registry.unregistered().for_each(|i| {
+        warn!(
+            "Unregistered item in registry {}, item index: {}",
+            type_name::<R>(),
+            i
+        );
+    });
+}
+
+pub trait RegistryItem: Sync + Send + 'static {
+    type R: Registry;
+
+    fn id() -> <Self::R as Registry>::Id;
+}
+
+pub trait Registry: Sync + Send + 'static {
+    type Id: Clone + Sync + Send + Into<usize> + 'static;
+
+    fn next_id() -> &'static Mutex<Self::Id>;
+}
+
+#[derive(Resource, Debug)]
+pub struct RegistryData<R: Registry> {
+    names2id: HashMap<&'static str, R::Id>,
+    id2names: Vec<Option<&'static str>>,
+}
+
+impl<R: Registry> RegistryData<R> {
+    pub fn add(&mut self, name: &'static str, id: R::Id) {
+        self.names2id.insert(name, id.clone());
+        let id = id.into();
+        if self.id2names.len() <= id {
+            self.id2names.resize(id + 1, None);
+        }
+        self.id2names[id] = Some(name);
+    }
+
+    pub fn name(&self, id: R::Id) -> Option<&'static str> {
+        self.id2names.get(id.into()).cloned().flatten()
+    }
+
+    pub fn id(&self, name: &str) -> Option<R::Id> {
+        self.names2id.get(name).cloned()
+    }
+
+    pub fn unregistered(&self) -> impl Iterator<Item = usize> + '_ {
+        let len: usize = R::next_id().lock().clone().into();
+
+        self.id2names
+            .iter()
+            .cloned()
+            .chain(iter::repeat(None).take(len - self.id2names.len()))
+            .enumerate()
+            .filter(|(_, o)| o.is_none())
+            .map(|(i, _)| i)
+    }
+
+    pub fn remove(&mut self, id: R::Id) -> bool {
+        let id: usize = id.into();
+        if let Some(Some(ref name)) = self.id2names.get(id) {
+            self.names2id.remove(name);
+            self.id2names[id] = None;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<R: Registry> Default for RegistryData<R> {
+    fn default() -> Self {
+        Self {
+            names2id: HashMap::new(),
+            id2names: Vec::new(),
+        }
+    }
+}
+
+pub trait RegistryAppMethods {
+    fn register_item<I: RegistryItem>(&mut self, name: &'static str) -> &mut Self;
+}
+
+impl RegistryAppMethods for App {
+    fn register_item<I: RegistryItem>(&mut self, name: &'static str) -> &mut Self {
+        self.init_resource::<RegistryData<I::R>>();
+        self.world
+            .resource_mut::<RegistryData<I::R>>()
+            .add(name, I::id());
+        self
+    }
+}
+
+#[macro_export]
+macro_rules! new_registry {
+    ($registry: ident, $id: ty) => {
+        pub struct $registry;
+
+        $crate::__private::paste::paste! {
+            #[doc(hidden)]
+            #[allow(non_upper_case_globals)]
+            static [<__ $registry _NEXT_ID>]: $crate::__private::parking_lot::Mutex<$id> =
+                $crate::__private::parking_lot::Mutex::<$id>::new(0);
+        }
+
+        impl $crate::Registry for $registry {
+            type Id = $id;
+
+            fn next_id() -> &'static $crate::__private::parking_lot::Mutex<$id> {
+                $crate::__private::paste::paste! {
+                    &[<__ $registry _NEXT_ID>]
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! new_item {
+    ($item: ident, $registry: ty) => {
+        pub struct $item;
+
+        $crate::__private::paste::paste! {
+            #[doc(hidden)]
+            #[$crate::__private::ctor::ctor]
+            #[allow(non_upper_case_globals)]
+            static [<__ $item _ID>]: <$registry as $crate::Registry>::Id = {
+                let mut lock = <$registry as $crate::Registry>::next_id().lock();
+                let id = *lock;
+                *lock += 1;
+                id
+            };
+        }
+
+        impl $crate::RegistryItem for $item {
+            type R = $registry;
+
+            fn id() -> <Self::R as $crate::Registry>::Id {
+                $crate::__private::paste::paste! {
+                    *[<__ $item _ID>]
+                }
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    new_item!(TestItem1, TestRegistry);
+    new_registry!(TestRegistry, u8);
+    new_item!(TestItem2, TestRegistry);
+
+    #[test]
+    fn easy_test() {
+        assert!(
+            TestItem1::id() == 0 || TestItem2::id() == 0,
+            "1: {}, 2: {}",
+            TestItem1::id(),
+            TestItem2::id()
+        );
+        assert!(
+            TestItem1::id() == 1 || TestItem2::id() == 1,
+            "1: {}, 2: {}",
+            TestItem1::id(),
+            TestItem2::id()
+        );
+        assert_ne!(TestItem1::id(), TestItem2::id());
+    }
+
+    #[test]
+    fn bevy_test() {
+        let mut app = App::new();
+
+        app.add_plugins(RegistryPlugin::<TestRegistry>::default())
+            .register_item::<TestItem1>("Test1");
+
+        let registry_data = app.world.resource::<RegistryData<TestRegistry>>();
+
+        assert_eq!(
+            registry_data.unregistered().collect::<Vec<_>>(),
+            vec![TestItem2::id() as usize]
+        );
+
+        assert_eq!(registry_data.id("Test1"), Some(TestItem1::id()),);
+        assert_eq!(registry_data.name(TestItem1::id()), Some("Test1"));
+        assert_eq!(registry_data.id("Test2"), None);
+        assert_eq!(registry_data.name(TestItem2::id()), None);
+    }
+}

--- a/examples/binding.rs
+++ b/examples/binding.rs
@@ -1,24 +1,53 @@
-use bevy::prelude::*;
-use rgl_input::{BindingPlugin, BindingApp, Key, Binding, BindingId};
-
-pub struct YoBinding;
-
-pub struct NotYoBinding;
+use bevy::{
+    prelude::*,
+    render::{
+        settings::{Backends, RenderCreation, WgpuSettings},
+        RenderPlugin,
+    },
+};
+use rgl_input::*;
+use rgl_registry::new_registry_items;
 
 fn main() {
     App::new()
         .add_plugins(BindingPlugin)
-        .add_plugins(DefaultPlugins)
-        .register_binding::<YoBinding>(Key::Keyboard(KeyCode::Q))
-        .register_binding::<NotYoBinding>(Key::Keyboard(KeyCode::E))
+        .add_plugins(DefaultPlugins.set(RenderPlugin {
+            render_creation: RenderCreation::Automatic(WgpuSettings {
+                backends: Some(Backends::VULKAN),
+                ..Default::default()
+            }),
+        }))
         .add_systems(Update, yo_not_yo)
+        .add_systems(Startup, setup)
+        .register_binding::<YoBinding>("yo", Key::Keyboard(KeyCode::Q))
+        .register_binding::<NotYoBinding>("not_yo", Key::Keyboard(KeyCode::E))
         .run();
 }
 
-fn yo_not_yo(yo_binding: Binding<YoBinding>, not_yo_binding: Binding<NotYoBinding>, bindings: Res<Input<BindingId>>) {
-    if bindings.just_pressed(yo_binding.id) {
-        println!("Yo!");
-    } else if bindings.just_pressed(not_yo_binding.id) {
-        println!("Not yo :(");
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+
+    commands.spawn(SpriteBundle {
+        sprite: Sprite {
+            color: Color::WHITE,
+            custom_size: Some(Vec2::splat(50.0)),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
+new_registry_items!(BindingRegistry {
+    YoBinding,
+    NotYoBinding,
+});
+
+fn yo_not_yo(bindings: Res<BindingStates>, mut sprite: Query<&mut Sprite>) {
+    let mut sprite = sprite.single_mut();
+
+    if bindings.value_ty::<YoBinding>().unwrap().just_pressed() {
+        sprite.color = Color::YELLOW;
+    } else if bindings.value_ty::<NotYoBinding>().unwrap().just_pressed() {
+        sprite.color = Color::BLUE;
     }
 }

--- a/examples/level.rs
+++ b/examples/level.rs
@@ -1,31 +1,24 @@
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
 use rgl_level::{
-    DefaultLevelObject, DefaultLevel, Layer, LayerBundle, Level, LevelBundle, LevelObjectRarity,
+    DefaultLevel, DefaultLevelObject, Layer, LayerBundle, Level, LevelBundle, LevelObjectRarity,
     LevelPlugin,
 };
-use rgl_registry::{
-    new_registry, new_registry_item, RegistryAppMethods, RegistryId, RegistryPlugin,
-};
+use rgl_registry::*;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(TilemapPlugin)
         .add_plugins(LevelPlugin)
-        .add_plugins(RegistryPlugin::<LevelTileRegistry>::default())
-        .register_item::<Floor>("floor")
-        .register_item::<Wall>("wall")
-        .register_item::<Air>("air")
-        .register_item::<LevelTileRegistry>("level_tile")
+        .register_two_sided_data_id2value::<LevelTileRegistry, &'static str>("level_tile")
         .add_systems(Startup, setup)
         .run()
 }
 
 new_registry!(LevelTileRegistry, u16);
-new_registry_item!(Floor, LevelTileRegistry);
-new_registry_item!(Wall, LevelTileRegistry);
-new_registry_item!(Air, LevelTileRegistry);
+
+new_registry_items!(LevelTileRegistry { Floor, Wall, Air });
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
@@ -37,10 +30,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     layer.add_object(
         Box::new(DefaultLevelObject::new(
-            Some(RegistryId::from_item::<DefaultLevel>()),
+            Some(RegistryId::new::<DefaultLevel>()),
             {
                 let mut tiles = [None; 9];
-                tiles[4] = Some(RegistryId::from_item::<Floor>());
+                tiles[4] = Some(RegistryId::new::<Floor>());
                 tiles
             },
             TileTextureIndex(0),
@@ -50,10 +43,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     layer.add_object(
         Box::new(DefaultLevelObject::new(
-            Some(RegistryId::from_item::<DefaultLevel>()),
+            Some(RegistryId::new::<DefaultLevel>()),
             {
                 let mut tiles = [None; 9];
-                tiles[4] = Some(RegistryId::from_item::<Wall>());
+                tiles[4] = Some(RegistryId::new::<Wall>());
                 tiles
             },
             TileTextureIndex(1),
@@ -65,12 +58,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn(LevelBundle::from_level(Level::from_tiles([
         [
-            RegistryId::from_item::<Floor>(),
-            RegistryId::from_item::<Floor>(),
+            RegistryId::new::<Floor>(),
+            RegistryId::new::<Floor>(),
         ],
         [
-            RegistryId::from_item::<Air>(),
-            RegistryId::from_item::<Wall>(),
+            RegistryId::new::<Air>(),
+            RegistryId::new::<Wall>(),
         ],
     ])));
 }

--- a/examples/level.rs
+++ b/examples/level.rs
@@ -1,23 +1,31 @@
-use std::any::TypeId;
-
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
-use rgl_level::{DefaultLevelObject, Layer, LayerBundle, Level, LevelBundle, LevelPlugin, LevelObjectRarity};
+use rgl_level::{
+    DefaultLevelObject, DefaultLevel, Layer, LayerBundle, Level, LevelBundle, LevelObjectRarity,
+    LevelPlugin,
+};
+use rgl_registry::{
+    new_registry, new_registry_item, RegistryAppMethods, RegistryId, RegistryPlugin,
+};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(TilemapPlugin)
         .add_plugins(LevelPlugin)
+        .add_plugins(RegistryPlugin::<LevelTileRegistry>::default())
+        .register_item::<Floor>("floor")
+        .register_item::<Wall>("wall")
+        .register_item::<Air>("air")
+        .register_item::<LevelTileRegistry>("level_tile")
         .add_systems(Startup, setup)
         .run()
 }
 
-struct Wall;
-
-struct Floor;
-
-struct Air;
+new_registry!(LevelTileRegistry, u16);
+new_registry_item!(Floor, LevelTileRegistry);
+new_registry_item!(Wall, LevelTileRegistry);
+new_registry_item!(Air, LevelTileRegistry);
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
@@ -27,51 +35,42 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     layer.tile_size = Vec2::splat(16.0).into();
     layer.texture = TilemapTexture::Single(asset_server.load("test_tiles.png"));
 
-    layer.add_object(Box::new(DefaultLevelObject {
-        bundle: TileTextureIndex(0),
-        level_kind: None,
-        tiles: [
-            None,
-            None,
-            None,
-            None,
-            Some(TypeId::of::<Floor>()),
-            None,
-            None,
-            None,
-            None,
-        ],
-    }), LevelObjectRarity::COMMON);
+    layer.add_object(
+        Box::new(DefaultLevelObject::new(
+            Some(RegistryId::from_item::<DefaultLevel>()),
+            {
+                let mut tiles = [None; 9];
+                tiles[4] = Some(RegistryId::from_item::<Floor>());
+                tiles
+            },
+            TileTextureIndex(0),
+        )),
+        LevelObjectRarity::COMMON,
+    );
 
-    layer.add_object(Box::new(DefaultLevelObject {
-        bundle: TileTextureIndex(1),
-        level_kind: None,
-        tiles: [
-            None,
-            None,
-            None,
-            None,
-            Some(TypeId::of::<Wall>()),
-            None,
-            None,
-            None,
-            None,
-        ],
-    }), LevelObjectRarity::COMMON);
+    layer.add_object(
+        Box::new(DefaultLevelObject::new(
+            Some(RegistryId::from_item::<DefaultLevel>()),
+            {
+                let mut tiles = [None; 9];
+                tiles[4] = Some(RegistryId::from_item::<Wall>());
+                tiles
+            },
+            TileTextureIndex(1),
+        )),
+        LevelObjectRarity::COMMON,
+    );
 
     commands.spawn(LayerBundle::from_layer(layer));
 
-    commands.spawn(LevelBundle {
-        level: Level {
-            tiles: vec![
-                TypeId::of::<Floor>(),
-                TypeId::of::<Floor>(),
-                TypeId::of::<Wall>(),
-                TypeId::of::<Air>(),
-            ],
-            size: IVec2::splat(2),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
+    commands.spawn(LevelBundle::from_level(Level::from_tiles([
+        [
+            RegistryId::from_item::<Floor>(),
+            RegistryId::from_item::<Floor>(),
+        ],
+        [
+            RegistryId::from_item::<Air>(),
+            RegistryId::from_item::<Wall>(),
+        ],
+    ])));
 }


### PR DESCRIPTION
# Registry
Registry is a struct, that implements `Registry` trait, which gives a way to count ids

# Item
Each item has its own registry and its own id, that it gets using `Registry` way of counting ids. Each registry is also an item of `RegistriesRegistry` registry, which is the only one registry, that shouldn't implement `RegistryItem` trait

# RegistryData
Is a resource, that has mappings for items in registry (name -> id, id -> name)

# Id
Is an object, that can be converted to usize. Also ids of items should go one after one (+1 from previous id), that gives us a way to store a value of all items using vectors, the size of which are known

## Example
```rust
new_registry!(TestRegistry, u8);
new_registry_items!(TestRegistry {
  TestItem1,
  TestItem2,
});

// Id of first item
let id1: u8 = TestItem1::id();
// Id of second item
let id2: u8 = TestItem2::id();

// Special struct, that is created to store RegistryIds more conveniently
let rid: RegistryId<TestRegistry> = RegistryId::from_item::<TestItem1>();

// Special struct, that stores registry id, when you don't know registry type itself
let unrid = UnknownRegistryId::from(rid);
```